### PR TITLE
chore: update terragrunt reference to 1.1.1, mcp sdk to 1.29.0, and fix eslint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 * **ci:** Corrige o workflow de release para fazer o upload de artefatos ([a55e03b](https://github.com/nataliagranato/terragrunt-mcp-server/commit/a55e03b1db56338bd91334523ecbbf25883b779f))
 
+## [1.0.4](https://github.com/nataliagranato/terragrunt-mcp-server/compare/v1.0.3...v1.0.4) (2025-07-11)
+
+
+### Bug Fixes
+
+* **package:** atualiza o nome do pacote e adiciona configuração de publicação para o GitHub Packages ([ba14670](https://github.com/nataliagranato/terragrunt-mcp-server/commit/ba146707e4b01301713bdec41c254f9da3f3fd0f))
+
 ### [1.0.1](https://github.com/nataliagranato/terragrunt-mcp-server/compare/v1.0.0...v1.0.1) (2025-07-11)
 
 
@@ -17,4 +24,3 @@
 
 * Atualiza o package-lock.json ([50813e7](https://github.com/nataliagranato/terragrunt-mcp-server/commit/50813e711f92492e3b6254a0169e0a73b7fa063e))
 * **ci:** update pre-commit hooks to resolve Gitleaks compilation issue ([ee7772f](https://github.com/nataliagranato/terragrunt-mcp-server/commit/ee7772f3b3b6037f42f35da38cf158de6586f671))
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "terragrunt-mcp-server",
-    "version": "1.0.2",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "terragrunt-mcp-server",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nataliagranato/terragrunt-mcp-server",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "publishConfig": {
         "registry": "https://npm.pkg.github.com"
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções**
  - Atualizada a configuração de publicação do pacote para o GitHub Packages.
  - Corrigido o nome do pacote na configuração de distribuição.

- **Documentação**
  - Adicionada a entrada da versão 1.0.4, com registro das correções relacionadas ao pacote.
  - Ajustes de formatação realizados nos arquivos de configuração, sem alteração nas funcionalidades ou dependências.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->